### PR TITLE
added redborder-common dependency

### DIFF
--- a/packaging/rpm/redborder-cgroups.spec
+++ b/packaging/rpm/redborder-cgroups.spec
@@ -10,7 +10,7 @@ License:    GNU AGPLv3
 URL:        https://github.com/redBorder/redborder-cgroups
 Source0:    %{name}-%{version}.tar.gz
 
-Requires: jq
+Requires: jq redborder-common
 
 %description
 %{summary}
@@ -46,10 +46,11 @@ systemctl enable redborder-cgroups
 %doc
 
 %changelog
+* Tue Apr 23 2024 - Nils Verschaeve <nverschaeve@redborder.com>
+- added redborder-common dependency
 * Mon Mar 25 2024 - David Vanhoucke <dvanhoucke@redborder.com> - 0.1.1-1
 - added jq dependency
 * Fri Feb 23 2024 - Luis Blanco <ljblanco@redborder.com> - 0.1.0-1
 - Ruby wrapper added, and unmangle shebangs
 * Tue Sep 28 2023 - Miguel Álvarez <malvarez@redborder.com> - 0.0.1-1
 - Initial spec version
-

--- a/packaging/rpm/redborder-cgroups.spec
+++ b/packaging/rpm/redborder-cgroups.spec
@@ -10,7 +10,7 @@ License:    GNU AGPLv3
 URL:        https://github.com/redBorder/redborder-cgroups
 Source0:    %{name}-%{version}.tar.gz
 
-Requires: jq redborder-common
+Requires: jq
 
 %description
 %{summary}
@@ -32,7 +32,9 @@ install -m 0755 resources/scripts/* %{buildroot}/usr/lib/redborder/scripts/
 %pre
 
 %post
-/usr/lib/redborder/bin/rb_rubywrapper.sh -c
+if [ -x "/usr/lib/redborder/bin/rb_rubywrapper.sh" ]; then
+  /usr/lib/redborder/bin/rb_rubywrapper.sh -c
+fi
 systemctl daemon-reload
 systemctl enable redborder-cgroups
 
@@ -47,7 +49,7 @@ systemctl enable redborder-cgroups
 
 %changelog
 * Tue Apr 23 2024 - Nils Verschaeve <nverschaeve@redborder.com>
-- added redborder-common dependency
+- added ruby wrapper check
 * Mon Mar 25 2024 - David Vanhoucke <dvanhoucke@redborder.com> - 0.1.1-1
 - added jq dependency
 * Fri Feb 23 2024 - Luis Blanco <ljblanco@redborder.com> - 0.1.0-1


### PR DESCRIPTION
FIX: Now there is no error message when the package redborder-ips is installing. The package could not find the file rb_rubywrapper.sh from redborder-common, so the dependency is added.